### PR TITLE
Switch deploy branch to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: "Deploy"
 on:
   push:
     branches:
-      - master
+      - production
 
 jobs:
   tf-tests:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,4 +27,16 @@ jobs:
     needs: [tf-apply]
     runs-on: ubuntu-latest
     steps:
-      - run: "true"
+      - name: Send notification
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.0
+        if: vars.ZULIP_ORG != ''
+        with:
+         api-key: ${{ secrets.ZULIP_BOT_API_KEY }}
+         email: ${{ secrets.ZULIP_BOT_EMAIL }}
+         organization-url: https://${{ vars.ZULIP_ORG }}.zulipchat.com
+         type: stream
+         to: github
+         topic: ${{ github.event.repository.name }}
+         content: |
+          [${{ github.event.repository.name }}](${{ github.server_url }}/${{ github.repository }}) was deployed to production:
+          [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,9 @@ name: "Pull Request"
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   tf-tests:


### PR DESCRIPTION
Since merges go to master, there may be times when a deployment is not desired.

- Change the deployment workflow to run only on `production` branch.
- Configure the pull request workflow to also run on `master` after merging.